### PR TITLE
Fixing coveralls for koa-github

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "koa-sess": "*",
     "mocha": "*",
     "should": "2.1.1",
-    "supertest": "0.8.3"
+    "supertest": "0.8.3",
+    "coveralls": "^2.8.0"
   }
 }


### PR DESCRIPTION
Coveralls was broken because of lack in devDependencies
